### PR TITLE
Force Nokogori to parse the request as XML

### DIFF
--- a/lib/rack-superfeedr.rb
+++ b/lib/rack-superfeedr.rb
@@ -114,7 +114,7 @@ module Rack
           content = JSON.parse(req.body.read)
         elsif content_type == "application/atom+xml"
           # Let's parse the body as ATOM using nokogiri
-          content = Nokogiri.parse(req.body.read)
+          content = Nokogiri.XML(req.body.read)
         end
         # Let's now send that data back to the user.
         if !@callback.call(content, feed_id[1])

--- a/rack-superfeedr.gemspec
+++ b/rack-superfeedr.gemspec
@@ -5,7 +5,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{rack-superfeedr}
-  s.version = "0.0.2"
+  s.version = "0.0.4"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["julien51"]


### PR DESCRIPTION
Nokogiri by default tries to be smart and guess if the given string should be parsed as HTML or XML, then parses it with the according parser. But sometimes it gets it wrong. Given that, I think it is best for now to force it to parse the notification as XML.

(also bumped the gem version by two, because it wasn't bumped in the previous release it seems (?) and now it needs to be bumped again (?) )
