### PR TITLE
Add request info parameter to notification callback

### DIFF
--- a/rack-superfeedr.gemspec
+++ b/rack-superfeedr.gemspec
@@ -50,6 +50,7 @@ Gem::Specification.new do |s|
       s.add_runtime_dependency(%q<rack>, [">= 0"])
       s.add_runtime_dependency(%q<nokogiri>, [">= 0"])
       s.add_runtime_dependency(%q<typhoeus>, [">= 0"])
+      s.add_runtime_dependency(%q<hashie>, [">= 0"])
     else
       s.add_dependency(%q<rack>, [">= 0"])
       s.add_dependency(%q<nokogiri>, [">= 0"])


### PR DESCRIPTION
... used in the callback.

Allows for handling like this:

superfeedr.on_notification do |notification, feed_id, info|
  topic = req.env['HTTP_X_PUBSUBHUBBUB_TOPIC']
  body_text = info.body
end
