### PR TITLE
Gemspec: Remove duplicate dependencies

### DIFF
--- a/rack-superfeedr.gemspec
+++ b/rack-superfeedr.gemspec
@@ -47,8 +47,6 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<bundler>, ["~> 1.0.0"])
       s.add_development_dependency(%q<jeweler>, ["~> 1.6.4"])
       s.add_development_dependency(%q<rcov>, [">= 0"])
-      s.add_runtime_dependency(%q<nokogiri>, [">= 0"])
-      s.add_runtime_dependency(%q<typhoeus>, [">= 0"])
       s.add_runtime_dependency(%q<hashie>, [">= 0"])
     else
       s.add_dependency(%q<rack>, [">= 0"])
@@ -58,7 +56,6 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<bundler>, ["~> 1.0.0"])
       s.add_dependency(%q<jeweler>, ["~> 1.6.4"])
       s.add_dependency(%q<rcov>, [">= 0"])
-      s.add_dependency(%q<nokogiri>, [">= 0"])
       s.add_dependency(%q<typhoeus>, [">= 0"])
     end
   else
@@ -69,8 +66,6 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<bundler>, ["~> 1.0.0"])
     s.add_dependency(%q<jeweler>, ["~> 1.6.4"])
     s.add_dependency(%q<rcov>, [">= 0"])
-    s.add_dependency(%q<nokogiri>, [">= 0"])
-    s.add_dependency(%q<typhoeus>, [">= 0"])
   end
 end
 


### PR DESCRIPTION
Turns out some dependencies were declared more than once, not sure why. Seems that recent Bundler versions are raising a warning about it, whereas previously it wasn't noted.

The warning this fixes is:

rack-superfeedr at /the/path did not have a valid gemspec.

This prevents bundler from installing bins or native extensions, but that may not affect its functionality.
The validation message from Rubygems was:
  duplicate dependency on rack (>= 0), (>= 0) use:
    add_runtime_dependency 'rack', '>= 0', '>= 0'
